### PR TITLE
Add required repository for building openstack-swift

### DIFF
--- a/epel-7-x86_64-openio-sds-17.04.cfg
+++ b/epel-7-x86_64-openio-sds-17.04.cfg
@@ -65,4 +65,13 @@ enabled=0
 gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-OPENIO-0
 gpgcheck=1
 
+# This is needed to build custom openstack-swift
+[centos-openstack-ocata]
+name=CentOS-7 - OpenStack ocata
+baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-ocata/
+enabled=1
+# Signature checking disabled because mock does not autoinstall GPG keys
+gpgcheck=0
+#gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
+exclude=sip,PyQt4
 """


### PR DESCRIPTION
This will add openstack ocata version repository so that the openstack-macros package is available for mock to install as an openstack-swift build dependency.